### PR TITLE
Create mono-runner

### DIFF
--- a/backend/monolith/mono-runner/pom.xml
+++ b/backend/monolith/mono-runner/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Alexengrig Dev.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>mono</artifactId>
+        <groupId>dev.alexengrig.myim</groupId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mono-runner</artifactId>
+
+    <name>runner</name>
+    <description>Monolithic myim application runner</description>
+
+</project>

--- a/backend/monolith/mono-runner/src/main/java/dev/alexengrig/myim/mono/MyimApplication.java
+++ b/backend/monolith/mono-runner/src/main/java/dev/alexengrig/myim/mono/MyimApplication.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MyimApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MyimApplication.class, args);
+    }
+
+}

--- a/backend/monolith/mono-runner/src/main/resources/application.yml
+++ b/backend/monolith/mono-runner/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8080

--- a/backend/monolith/mono-runner/src/main/resources/application.yml
+++ b/backend/monolith/mono-runner/src/main/resources/application.yml
@@ -1,2 +1,6 @@
 server:
   port: 8080
+
+application:
+  title: myim
+  version: @project.version@

--- a/backend/monolith/mono-runner/src/main/resources/banner.txt
+++ b/backend/monolith/mono-runner/src/main/resources/banner.txt
@@ -1,0 +1,9 @@
+                      _
+  _ __ ___    _   _  (_)  _ __ ___
+ | '_ ` _ \  | | | | | | | '_ ` _ \
+ | | | | | | | |_| | | | | | | | | |
+ |_| |_| |_|  \__, | |_| |_| |_| |_|
+              |___/
+
+${application.title} ${application.version}
+Powered by Spring Boot ${spring-boot.version}

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -32,6 +32,42 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.boot.dependencies.version>2.6.3</spring.boot.dependencies.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 </project>

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -84,8 +84,24 @@
                         </excludes>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <configuration>
+                        <delimiters>
+                            <delimiter>@</delimiter>
+                        </delimiters>
+                        <useDefaultDelimiters>false</useDefaultDelimiters>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 
 </project>

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -27,6 +27,10 @@
 
     <description>Monolithic myim application</description>
 
+    <modules>
+        <module>mono-runner</module>
+    </modules>
+
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
@@ -65,6 +71,14 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
+                    <configuration>
+                        <excludes>
+                            <exclude>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                            </exclude>
+                        </excludes>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Alexengrig Dev.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dev.alexengrig.myim</groupId>
+    <artifactId>mono</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <description>Monolithic myim application</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>


### PR DESCRIPTION
Run logs:

```
                      _
  _ __ ___    _   _  (_)  _ __ ___
 | '_ ` _ \  | | | | | | | '_ ` _ \
 | | | | | | | |_| | | | | | | | | |
 |_| |_| |_|  \__, | |_| |_| |_| |_|
              |___/

myim 0.1.0-SNAPSHOT
Powered by Spring Boot 2.6.3

2022-01-22 00:50:40.843  INFO 7696 --- [           main] d.alexengrig.myim.mono.MyimApplication   : Starting MyimApplication using Java 17.0.1 on PC with PID 7696 (~/GitHub/alexengrig/myim/backend/monolith/mono-runner/target/classes started by alexengrig in ~/GitHub/alexengrig/myim)
2022-01-22 00:50:40.845  INFO 7696 --- [           main] d.alexengrig.myim.mono.MyimApplication   : No active profile set, falling back to default profiles: default
2022-01-22 00:50:41.176  INFO 7696 --- [           main] d.alexengrig.myim.mono.MyimApplication   : Started MyimApplication in 0.589 seconds (JVM running for 1.092)

Process finished with exit code 0
```