### PR TITLE
Create mono-recipient-service

### DIFF
--- a/backend/monolith/mono-recipient-service/pom.xml
+++ b/backend/monolith/mono-recipient-service/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Alexengrig Dev.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>dev.alexengrig.myim</groupId>
+        <artifactId>mono</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mono-recipient-service</artifactId>
+
+    <name>recipient-service</name>
+    <description>Monolithic myim recipient service</description>
+
+</project>

--- a/backend/monolith/mono-recipient-service/pom.xml
+++ b/backend/monolith/mono-recipient-service/pom.xml
@@ -30,4 +30,11 @@
     <name>recipient-service</name>
     <description>Monolithic myim recipient service</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -17,8 +17,10 @@
 package dev.alexengrig.myim.mono.recipient.controller;
 
 import dev.alexengrig.myim.mono.recipient.domain.ChatMessage;
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessageStatus;
 import dev.alexengrig.myim.mono.recipient.payload.ChatMessageRequest;
 import dev.alexengrig.myim.mono.recipient.payload.MessageRequest;
+import dev.alexengrig.myim.mono.recipient.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionService;
@@ -34,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatController {
 
+    private final ChatService chatService;
     private final ConversionService conversionService;
 
     @PostMapping("/{chatId}/messages")
@@ -43,7 +46,8 @@ public class ChatController {
         ChatMessageRequest request = messageRequest.withChatId(chatId);
         log.info("Create message: {}", request);
         ChatMessage message = conversionService.convert(request, ChatMessage.class);
-        log.info("Created message: {}", message);
+        ChatMessageStatus status = chatService.sendMessage(message);
+        log.info("Send status: {}", status);
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -16,10 +16,20 @@
 
 package dev.alexengrig.myim.mono.recipient.controller;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/recipient/chats")
 public class ChatController {
+
+    @PostMapping("/{chatId}/messages")
+    public void createMessage(@PathVariable String chatId) {
+        log.info("Create message for chatId={}", chatId);
+    }
+
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/recipient/chats")
+public class ChatController {
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -25,6 +25,7 @@ import dev.alexengrig.myim.mono.recipient.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,15 +42,16 @@ public class ChatController {
     private final ConversionService conversionService;
 
     @PostMapping("/{chatId}/messages")
-    public void createMessage(
+    public ResponseEntity<ChatMessageStatusResponse> createMessage(
             @PathVariable String chatId,
             @RequestBody MessageRequest messageRequest) {
         ChatMessageRequest request = messageRequest.withChatId(chatId);
-        log.info("Create message: {}", request);
+        log.info("Message creation request: {}", request);
         ChatMessage message = conversionService.convert(request, ChatMessage.class);
         ChatMessageStatus status = chatService.sendMessage(message);
         ChatMessageStatusResponse response = conversionService.convert(status, ChatMessageStatusResponse.class);
-        log.info("Send status: {}", response);
+        log.info("Message creation response: {}", response);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -19,6 +19,7 @@ package dev.alexengrig.myim.mono.recipient.controller;
 import dev.alexengrig.myim.mono.recipient.domain.ChatMessage;
 import dev.alexengrig.myim.mono.recipient.domain.ChatMessageStatus;
 import dev.alexengrig.myim.mono.recipient.payload.ChatMessageRequest;
+import dev.alexengrig.myim.mono.recipient.payload.ChatMessageStatusResponse;
 import dev.alexengrig.myim.mono.recipient.payload.MessageRequest;
 import dev.alexengrig.myim.mono.recipient.service.ChatService;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,8 @@ public class ChatController {
         log.info("Create message: {}", request);
         ChatMessage message = conversionService.convert(request, ChatMessage.class);
         ChatMessageStatus status = chatService.sendMessage(message);
-        log.info("Send status: {}", status);
+        ChatMessageStatusResponse response = conversionService.convert(status, ChatMessageStatusResponse.class);
+        log.info("Send status: {}", response);
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -16,6 +16,7 @@
 
 package dev.alexengrig.myim.mono.recipient.controller;
 
+import dev.alexengrig.myim.mono.recipient.payload.ChatMessageRequest;
 import dev.alexengrig.myim.mono.recipient.payload.MessageRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,7 +34,8 @@ public class ChatController {
     public void createMessage(
             @PathVariable String chatId,
             @RequestBody MessageRequest messageRequest) {
-        log.info("Create message for chatId={}: {}", chatId, messageRequest);
+        ChatMessageRequest request = messageRequest.withChatId(chatId);
+        log.info("Create message: {}", request);
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -16,9 +16,11 @@
 
 package dev.alexengrig.myim.mono.recipient.controller;
 
+import dev.alexengrig.myim.mono.recipient.payload.MessageRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,8 +30,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatController {
 
     @PostMapping("/{chatId}/messages")
-    public void createMessage(@PathVariable String chatId) {
-        log.info("Create message for chatId={}", chatId);
+    public void createMessage(
+            @PathVariable String chatId,
+            @RequestBody MessageRequest messageRequest) {
+        log.info("Create message for chatId={}: {}", chatId, messageRequest);
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/ChatController.java
@@ -16,9 +16,12 @@
 
 package dev.alexengrig.myim.mono.recipient.controller;
 
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessage;
 import dev.alexengrig.myim.mono.recipient.payload.ChatMessageRequest;
 import dev.alexengrig.myim.mono.recipient.payload.MessageRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,7 +31,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/recipient/chats")
+@RequiredArgsConstructor
 public class ChatController {
+
+    private final ConversionService conversionService;
 
     @PostMapping("/{chatId}/messages")
     public void createMessage(
@@ -36,6 +42,8 @@ public class ChatController {
             @RequestBody MessageRequest messageRequest) {
         ChatMessageRequest request = messageRequest.withChatId(chatId);
         log.info("Create message: {}", request);
+        ChatMessage message = conversionService.convert(request, ChatMessage.class);
+        log.info("Created message: {}", message);
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/chat.http
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/chat.http
@@ -1,1 +1,6 @@
 POST http://localhost:8080/api/v1/recipient/chats/1337/messages
+Content-Type: application/json
+
+{
+  "text": "Hello, world!"
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/chat.http
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/controller/chat.http
@@ -1,0 +1,1 @@
+POST http://localhost:8080/api/v1/recipient/chats/1337/messages

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/converter/ChatMessageRequest2ChatMessageConverter.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/converter/ChatMessageRequest2ChatMessageConverter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.converter;
+
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessage;
+import dev.alexengrig.myim.mono.recipient.payload.ChatMessageRequest;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatMessageRequest2ChatMessageConverter
+        implements Converter<ChatMessageRequest, ChatMessage> {
+
+    @Override
+    public ChatMessage convert(ChatMessageRequest source) {
+        return ChatMessage.builder()
+                .text(source.getText())
+                .chatId(source.getChatId())
+                .build();
+    }
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/converter/ChatMessageStatus2ChatMessageStatusResponseConverter.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/converter/ChatMessageStatus2ChatMessageStatusResponseConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.converter;
+
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessageStatus;
+import dev.alexengrig.myim.mono.recipient.payload.ChatMessageStatusResponse;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatMessageStatus2ChatMessageStatusResponseConverter
+        implements Converter<ChatMessageStatus, ChatMessageStatusResponse> {
+
+    @Override
+    public ChatMessageStatusResponse convert(ChatMessageStatus source) {
+        return ChatMessageStatusResponse.builder()
+                .description(source.getDescription())
+                .type(source.getType())
+                .chatId(source.getChatId())
+                .build();
+    }
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/ChatMessage.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/ChatMessage.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@ToString(callSuper = true)
+@SuperBuilder
+public class ChatMessage extends Message {
+
+    private String chatId;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/ChatMessageStatus.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/ChatMessageStatus.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@ToString(callSuper = true)
+public class ChatMessageStatus extends MessageStatus {
+
+    public String chatId;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/Message.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/Message.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@ToString
+@SuperBuilder
+public class Message {
+
+    private String text;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/MessageStatus.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/MessageStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@ToString
+@SuperBuilder
+public class MessageStatus {
+
+    private String description;
+    private MessageStatusType type;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/MessageStatusType.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/domain/MessageStatusType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.domain;
+
+public enum MessageStatusType {
+
+    SENT
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/ChatMessageRequest.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/ChatMessageRequest.java
@@ -16,30 +16,22 @@
 
 package dev.alexengrig.myim.mono.recipient.payload;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @Setter
-@ToString
+@ToString(callSuper = true)
 @SuperBuilder
-@NoArgsConstructor
-@AllArgsConstructor
-public class MessageRequest {
+public class ChatMessageRequest extends MessageRequest {
 
-    private String text;
+    private String chatId;
 
-    protected MessageRequest(MessageRequest that) {
-        this(that.text);
-    }
-
-    public ChatMessageRequest withChatId(String chatId) {
-        return new ChatMessageRequest(this, chatId);
+    protected ChatMessageRequest(MessageRequest parent, String chatId) {
+        super(parent);
+        this.chatId = chatId;
     }
 
 }

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/ChatMessageStatusResponse.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/ChatMessageStatusResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@ToString(callSuper = true)
+public class ChatMessageStatusResponse extends MessageStatusResponse {
+
+    public String chatId;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/MessageRequest.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/MessageRequest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class MessageRequest {
+
+    private String text;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/MessageStatusResponse.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/payload/MessageStatusResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.payload;
+
+import dev.alexengrig.myim.mono.recipient.domain.MessageStatusType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@ToString
+@SuperBuilder
+public class MessageStatusResponse {
+
+    private String description;
+    private MessageStatusType type;
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/service/ChatService.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/service/ChatService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.service;
+
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessage;
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessageStatus;
+
+public interface ChatService {
+
+    ChatMessageStatus sendMessage(ChatMessage message);
+
+}

--- a/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/service/LogChatService.java
+++ b/backend/monolith/mono-recipient-service/src/main/java/dev/alexengrig/myim/mono/recipient/service/LogChatService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Alexengrig Dev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.alexengrig.myim.mono.recipient.service;
+
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessage;
+import dev.alexengrig.myim.mono.recipient.domain.ChatMessageStatus;
+import dev.alexengrig.myim.mono.recipient.domain.MessageStatusType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+public class LogChatService implements ChatService {
+
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    @Override
+    public ChatMessageStatus sendMessage(ChatMessage message) {
+        log.info("Send message: {}", message);
+        LocalDateTime sentAt = LocalDateTime.now();
+        String description = "Message sent at " + dateTimeFormatter.format(sentAt);
+        return ChatMessageStatus.builder()
+                .chatId(message.getChatId())
+                .description(description)
+                .type(MessageStatusType.SENT)
+                .build();
+    }
+
+}

--- a/backend/monolith/mono-runner/pom.xml
+++ b/backend/monolith/mono-runner/pom.xml
@@ -31,4 +31,11 @@
     <name>runner</name>
     <description>Monolithic myim application runner</description>
 
+    <dependencies>
+        <dependency>
+            <groupId>dev.alexengrig.myim</groupId>
+            <artifactId>mono-recipient-service</artifactId>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -28,6 +28,7 @@
     <description>Monolithic myim application</description>
 
     <modules>
+        <module>mono-recipient-service</module>
         <module>mono-runner</module>
     </modules>
 

--- a/backend/monolith/pom.xml
+++ b/backend/monolith/pom.xml
@@ -49,6 +49,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>dev.alexengrig.myim</groupId>
+                <artifactId>mono-recipient-service</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Send message to chat: 

```bash
curl -X POST http://localhost:8080/api/v1/recipient/chats/1337/messages
    -H 'Content-Type: application/json'
    -d '{"login":"my_login","password":"my_password"}'
```

And get response:

`{"description":"Message sent at 2022-01-22T02:31:20.139577","type":"SENT","chatId":"1337"}`

Logs:

```
2022-01-22 02:31:20.129  INFO 21916 --- [nio-8080-exec-1] d.a.m.m.r.controller.ChatController      : Message creation request: ChatMessageRequest(super=MessageRequest(text=null), chatId=1337)
2022-01-22 02:31:20.134  INFO 21916 --- [nio-8080-exec-1] d.a.m.m.r.service.LogChatService         : Send message: ChatMessage(super=Message(text=null), chatId=1337)
2022-01-22 02:31:20.143  INFO 21916 --- [nio-8080-exec-1] d.a.m.m.r.controller.ChatController      : Message creation response: ChatMessageStatusResponse(super=MessageStatusResponse(description=Message sent at 2022-01-22T02:31:20.139577, type=SENT), chatId=1337)
```
